### PR TITLE
feat: add breadcrumb component

### DIFF
--- a/src/elements/components/breadcrumb/breadcrumb.css
+++ b/src/elements/components/breadcrumb/breadcrumb.css
@@ -1,0 +1,25 @@
+@import '~/styles/build.css';
+
+.pa-breadcrumb {
+  display: block;
+}
+
+.pa-breadcrumb__list {
+  list-style: none;
+  display: flex;
+  margin: 0;
+  padding: 0;
+}
+
+.pa-breadcrumb__item {
+  display: flex;
+  align-items: center;
+}
+
+.pa-breadcrumb__link {
+  text-decoration: none;
+}
+
+.pa-breadcrumb__separator {
+  margin: 0 0.5rem;
+}

--- a/src/elements/components/breadcrumb/breadcrumb.lite.tsx
+++ b/src/elements/components/breadcrumb/breadcrumb.lite.tsx
@@ -1,0 +1,41 @@
+import { For, Show, useMetadata, useStore } from '@builder.io/mitosis';
+import './breadcrumb.css';
+import type { BreadcrumbProps, BreadcrumbState } from './breadcrumb.model';
+import { breadcrumbService } from './breadcrumb.service';
+
+useMetadata({ isAttachedToShadowDom: true });
+
+export default function Breadcrumb(props: BreadcrumbProps) {
+  const state = useStore<BreadcrumbState>({
+    get classes() {
+      return breadcrumbService.getClasses(props.className || props.classList);
+    },
+    get separator() {
+      return props.separator || '/';
+    }
+  });
+
+  return (
+    <nav class={state.classes.base} aria-label="breadcrumb">
+      <ol class="pa-breadcrumb__list">
+        <For each={props.items}>
+          {(item, index) => (
+            <li class="pa-breadcrumb__item">
+              <Show when={item.href}>
+                <a class="pa-breadcrumb__link" href={item.href}>
+                  {item.label}
+                </a>
+              </Show>
+              <Show when={!item.href}>
+                <span class="pa-breadcrumb__link">{item.label}</span>
+              </Show>
+              <Show when={index !== props.items.length - 1}>
+                <span class="pa-breadcrumb__separator">{state.separator}</span>
+              </Show>
+            </li>
+          )}
+        </For>
+      </ol>
+    </nav>
+  );
+}

--- a/src/elements/components/breadcrumb/breadcrumb.model.ts
+++ b/src/elements/components/breadcrumb/breadcrumb.model.ts
@@ -1,0 +1,16 @@
+import type { BaseProps, BaseState } from '~/models';
+
+export interface BreadcrumbItem {
+  label: string;
+  href?: string;
+}
+
+export interface BreadcrumbProps extends BaseProps {
+  items: BreadcrumbItem[];
+  separator?: string;
+}
+
+export interface BreadcrumbState extends BaseState {
+  classes: { base: string };
+  separator: string;
+}

--- a/src/elements/components/breadcrumb/breadcrumb.service.ts
+++ b/src/elements/components/breadcrumb/breadcrumb.service.ts
@@ -1,0 +1,12 @@
+import { classesToString, debug } from '~/helpers';
+
+class BreadcrumbService {
+  public getClasses(className: string) {
+    const base = classesToString(['pa-breadcrumb', className || '']);
+
+    debug(`BreadcrumbService getClasses: base: ${base}`);
+    return { base };
+  }
+}
+
+export const breadcrumbService = new BreadcrumbService();

--- a/src/elements/components/breadcrumb/breadcrumb.stories.mdx
+++ b/src/elements/components/breadcrumb/breadcrumb.stories.mdx
@@ -1,0 +1,105 @@
+import { Canvas, Meta, Story, ArgsTable } from '@storybook/addon-docs';
+import { Breadcrumb } from '../../../../packages/react/src';
+import { Codesandbox } from '../../../../.storybook/components';
+
+<Meta
+  title="🧩Elements/Components/Breadcrumb"
+  component={Breadcrumb}
+  argTypes={{
+    separator: {
+      name: 'separator',
+      description: 'String used to separate items',
+      table: {},
+      control: { type: 'text' }
+    }
+  }}
+/>
+
+export const Template = (args) => (
+  <Breadcrumb
+    {...args}
+    items={[
+      { label: 'Home', href: '#' },
+      { label: 'Library', href: '#' },
+      { label: 'Data' }
+    ]}
+  />
+);
+
+# Breadcrumb
+
+Breadcrumbs display the current location within a hierarchy and allow navigation.
+
+## Showcase
+
+<Canvas>
+  <Story name="Breadcrumb" args={{ separator: '/' }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+### Properties
+
+<ArgsTable story="Breadcrumb" of={Breadcrumb} />
+
+## How to use this component
+
+### Angular
+
+<Codesandbox
+  components={['Breadcrumb']}
+  platform="angular"
+  code={`<nav pa-breadcrumb [items]="[{ label: 'Home', href: '/' }, { label: 'Current' }]"></nav>`}
+/>
+
+### Preact
+
+<Codesandbox
+  components={['Breadcrumb']}
+  platform="preact"
+  code={`<Breadcrumb items={[{ label: 'Home', href: '/' }, { label: 'Current' }]} />`}
+/>
+
+### Qwik
+
+<Codesandbox
+  components={['Breadcrumb']}
+  platform="qwik"
+  code={`<Breadcrumb items={[{ label: 'Home', href: '/' }, { label: 'Current' }]} />`}
+/>
+
+### React
+
+<Codesandbox
+  components={['Breadcrumb']}
+  platform="react"
+  code={`<Breadcrumb items={[{ label: 'Home', href: '/' }, { label: 'Current' }]} />`}
+/>
+
+### Solid
+
+<Codesandbox
+  components={['Breadcrumb']}
+  platform="solid"
+  code={`<Breadcrumb items={[{ label: 'Home', href: '/' }, { label: 'Current' }]} />`}
+/>
+
+### Svelte
+
+<Codesandbox
+  components={['Breadcrumb']}
+  platform="svelte"
+  code={`<Breadcrumb items={[{ label: 'Home', href: '/' }, { label: 'Current' }]} />`}
+/>
+
+### Vue
+
+<Codesandbox
+  components={['Breadcrumb']}
+  platform="vue"
+  code={`<Breadcrumb :items="[{ label: 'Home', href: '/' }, { label: 'Current' }]" />`}
+/>
+
+### Web Components
+
+<Codesandbox components={['Breadcrumb']} platform="webcomponents" code={`<pa-breadcrumb items='[{ "label": "Home", "href": "/" }, { "label": "Current" }]' ></pa-breadcrumb>`} />

--- a/src/elements/components/breadcrumb/index.ts
+++ b/src/elements/components/breadcrumb/index.ts
@@ -1,0 +1,1 @@
+export { default } from './breadcrumb.lite';

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export { setDebugLevel, DebugLevel, addCodeLanguage, getPlatform, getVersion } f
 
 // Init Components
 export { default as Avatar } from './elements/components/avatar';
+export { default as Breadcrumb } from './elements/components/breadcrumb';
 export { default as Button } from './elements/components/button';
 export { default as Code } from './elements/components/code';
 export { default as Pill } from './elements/components/pill';


### PR DESCRIPTION
## Summary
- add reusable breadcrumb component with items and separator support
- expose Breadcrumb from library entry point
- document Breadcrumb usage in Storybook

## Testing
- `yarn lint:scripts`
- `yarn lint:styles`


------
https://chatgpt.com/codex/tasks/task_e_68a816a01ad08332bd0ee00d6c7d3344