### PR TITLE
Handle missing theme directory in Storybook build

### DIFF
--- a/.storybook/main.cjs
+++ b/.storybook/main.cjs
@@ -1,9 +1,14 @@
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
+const fs = require('fs');
+const path = require('path');
+
+const themeDir = path.resolve(__dirname, '../.themes');
+const staticDirs = fs.existsSync(themeDir) ? ['../.themes'] : [];
 
 module.exports = {
   stories: ['../docs/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx|mdx)'],
-  staticDirs: ['../.themes'],
+  staticDirs,
   core: {
     builder: 'webpack4'
   },


### PR DESCRIPTION
## Summary
- avoid Storybook build crash when `.themes` folder is absent

## Testing
- `yarn build-storybook`


------
https://chatgpt.com/codex/tasks/task_e_68a81a296ab48332910badbcf8a64d91